### PR TITLE
Update default-colors.scss

### DIFF
--- a/src/common-ui/scss/default-colors.scss
+++ b/src/common-ui/scss/default-colors.scss
@@ -41,6 +41,10 @@ $text-color  :   darkslateblue;
   background-color: rgba(200, 200, 200, 0.6);
 }
 
+%shadow-transition {
+  transition: border 0.2s linear 0s, box-shadow 0.2s linear 0s;
+}
+
 // some usefull macros
 @mixin hover-background {
   background-color: $hover-color !important;
@@ -96,7 +100,7 @@ $text-color  :   darkslateblue;
 @mixin label-success {
   border-color: rgba(154, 205, 50, 0.6)!important;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.075) inset, 0 0 8px rgba(154, 205, 50, 0.6)!important;
-  @extend .shadow-transition;
+  @extend %shadow-transition;
 }
 
 @mixin label-hover {


### PR DESCRIPTION
Fix to correct the error "The selector "%shadow-transition" was not found."

Running "sass:dist" (sass) task
>> Error: ".ajm-matrix-label.ajg-error" failed to @extend "%shadow-transition".
>>        The selector "%shadow-transition" was not found.
>>        Use "@extend %shadow-transition !optional" if the extend should be able to fail.
>>         on line 92 of scss/default-colors.scss
>> >>   @extend %shadow-transition;
>>    --^
Warning:  Use --force to continue.